### PR TITLE
Avoid overuse of memory

### DIFF
--- a/ResampleTool_R_notebook.ipynb
+++ b/ResampleTool_R_notebook.ipynb
@@ -40,18 +40,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Step 2: Reading in the data and dealing with invalid (no-data) pixels\n",
+    "# Step 2: Reading in the data\n",
     "\n",
     "Once the data set is available, *raster* package functionality is used to prepare it for resampling. The use of the *knitr* package is optional, it only helps with pretty-printing tables."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
-    "lines_to_next_cell": 2
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Loading required package: sp\n",
+      "\n",
+      "Loading required package: knitr\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "library(raster)\n",
     "if(require(knitr) == FALSE){install.packages(\"knitr\", repos = \"https://cloud.r-project.org\"); library(knitr)} else {library(knitr)}\n",
@@ -62,60 +75,6 @@
     "\n",
     "# Note: Some warnings appear when reading in the netCDF with raster(). The one realted to variable name is irrelevant. The one related to CRS has no consequences on raster's spatial information"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The original Global Land product files typically come in two flavours: the global netCDF4 files (the native production format) or GeoTIFF subsets. Both can contain specific values (flags) for invalid pixels, which need to be dealt with. For this example, we’ll convert those into NoData (NA) values.\n",
-    "\n",
-    "The range of valid pixel values, the scale factor and offset and any flag values used are described in the product documentation and netCDF file metadata.\n",
-    "\n",
-    "For your convenience, a short table was prepared summarizing the range of valid values, both in raw digital number (DN) and physical value, for each product, version and data layer. Let’s read in this table from the csv file. \n",
-    "\n",
-    "The physical or real value is computed as digital number * scale + offset, but this applies only for valid pixels."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove_input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "cutoff_method_df <- read.csv(paste0(getwd(), \"/Table_cutoff_and_resampleMethod.csv\"),\n",
-    "                             stringsAsFactors = FALSE,\n",
-    "                             header = TRUE)\n",
-    "kable(cutoff_method_df[, 1:8], caption = \"\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For example, in the 300m NDVI products, digital values > 250 are flagged and need to be converted into NA. When netCDF files are read in as a *Raster*\\* object, the digital values are scaled into real NDVI values automatically. To make sure to not use any of the invalid (flagged) pixels, we’ll have to be set all pixels with > 0.92 (=DN 250 x scale + offset) to NA.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "outputs": [],
-   "source": [
-    "cutoff_flag <- 0.92\n",
-    "\n",
-    "r[r > cutoff_flag] <- NA"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -149,11 +108,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "lines_to_next_cell": 0
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1] \"The image is not the full product; therefore, extent needs to be checked\"\n"
+     ]
+    }
+   ],
    "source": [
     "if(extent(r)[1] < -180 & extent(r)[2] > 179.997 &\n",
     "   extent(r)[3] < -59.99554 & extent(r)[4] > 80){  # checking for full product (image)\n",
@@ -167,11 +134,6 @@
     "  print(\"The image is not the full product; therefore, extent needs to be checked\")\n",
     "}"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -213,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -232,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "echo": true,
     "lines_to_next_cell": 2
@@ -258,14 +220,111 @@
     "  \n",
     "  # Now we can crop the 300m raster\n",
     "  r <- crop(r, my_extent)\n",
-    "}"
+    "}\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Step 4: Resampling using the aggregation approach\n",
+    "# Step 4: Dealing with invalid (no-data) pixels\n",
+    "\n",
+    "The original Global Land product files typically come in two flavours: the global netCDF4 files (the native production format) or GeoTIFF subsets. Both can contain specific values (flags) for invalid pixels, which need to be dealt with. For this example, we’ll convert those into NoData (NA) values.\n",
+    "\n",
+    "The range of valid pixel values, the scale factor and offset and any flag values used are described in the product documentation and netCDF file metadata.\n",
+    "\n",
+    "For your convenience, a short table was prepared summarizing the range of valid values, both in raw digital number (DN) and physical value, for each product, version and data layer. Let’s read in this table from the csv file.\n",
+    "\n",
+    "The physical or real value is computed as digital number * scale + offset, but this applies only for valid pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "\n",
+       "Table: \n",
+       "\n",
+       "|Product     |Version |Data.layer.in.file | Bytes.per.Cell| Valid.DN.min| Valid.DN.max| Valid.physical.min| Valid.physical.max|\n",
+       "|:-----------|:-------|:------------------|--------------:|------------:|------------:|------------------:|------------------:|\n",
+       "|NDVI 300m   |v1      |NDVI               |              1|            0|          250|              -0.08|               0.92|\n",
+       "|NDVI 300m   |v1      |NDVI_unc           |              2|            0|         1000|               0.00|               1.00|\n",
+       "|LAI 300m    |v1      |LAI                |              1|            0|          210|               0.00|               7.00|\n",
+       "|LAI 300m    |v1      |RMSE               |              1|            0|          210|               0.00|               7.00|\n",
+       "|LAI 300m    |v1      |LENGTH_AFTER       |              1|            0|           60|               0.00|              60.00|\n",
+       "|LAI 300m    |v1      |LENGTH_BEFORE      |              1|           15|          210|              15.00|             210.00|\n",
+       "|LAI 300m    |v1      |NOBS               |              1|            0|           40|               0.00|              40.00|\n",
+       "|LAI 300m    |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
+       "|FAPAR 300m  |v1      |FAPAR              |              1|            0|          235|               0.00|               0.94|\n",
+       "|FAPAR 300m  |v1      |RMSE               |              1|            0|          235|               0.00|               0.94|\n",
+       "|FAPAR 300m  |v1      |LENGTH_AFTER       |              1|            0|           60|               0.00|              60.00|\n",
+       "|FAPAR 300m  |v1      |LENGTH_BEFORE      |              1|           15|          210|              15.00|             210.00|\n",
+       "|FAPAR 300m  |v1      |NOBS               |              1|            0|           40|               0.00|              40.00|\n",
+       "|FAPAR 300m  |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
+       "|FCOVER 300m |v1      |FCOVER             |              1|            0|          250|               0.00|               1.00|\n",
+       "|FCOVER 300m |v1      |RMSE               |              1|            0|          250|               0.00|               1.00|\n",
+       "|FCOVER 300m |v1      |LENGTH_AFTER       |              1|            0|           60|               0.00|              60.00|\n",
+       "|FCOVER 300m |v1      |LENGTH_BEFORE      |              1|           15|          210|              15.00|             210.00|\n",
+       "|FCOVER 300m |v1      |NOBS               |              1|            0|           40|               0.00|              40.00|\n",
+       "|FCOVER 300m |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
+       "|DMP 300m    |v1      |DMP                |              2|            0|        32767|               0.00|             327.67|\n",
+       "|DMP 300m    |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
+       "|GDMP 300m   |v1      |GDMP               |              2|            0|        32767|               0.00|             655.34|\n",
+       "|GDMP 300m   |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cutoff_method_df <- read.csv(paste0(getwd(), \"/Table_cutoff_and_resampleMethod.csv\"),\n",
+    "                             stringsAsFactors = FALSE,\n",
+    "                             header = TRUE)\n",
+    "kable(cutoff_method_df[, 1:8], caption = \"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, in the 300m NDVI products, digital values > 250 are flagged and need to be converted into NA. When netCDF files are read in as a *Raster*\\* object, the digital values are scaled into real NDVI values automatically. To make sure to not use any of the invalid (flagged) pixels, we’ll have to be set all pixels with > 0.92 (=DN 250 x scale + offset) to NA.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cutoff_flag <- 0.92\n",
+    "\n",
+    "r[r > cutoff_flag] <- NA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Step 5: Resampling using the aggregation approach\n",
     "\n",
     "There are several approaches to resample data to a coarser resolution. The area-based aggregation methods group rectangular areas of cells of the finer resolution image to create a new map with larger cells. \n",
     "\n",
@@ -278,13 +337,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "tags": [
      "remove_input"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "\n",
+       "Table: \n",
+       "\n",
+       "|Product     |Version |Data.layer.in.file |Resample.method         |\n",
+       "|:-----------|:-------|:------------------|:-----------------------|\n",
+       "|NDVI 300m   |v1      |NDVI               |mean                    |\n",
+       "|NDVI 300m   |v1      |NDVI_unc           |uncertainty_propagation |\n",
+       "|LAI 300m    |v1      |LAI                |mean                    |\n",
+       "|LAI 300m    |v1      |RMSE               |mean                    |\n",
+       "|LAI 300m    |v1      |LENGTH_AFTER       |modal                   |\n",
+       "|LAI 300m    |v1      |LENGTH_BEFORE      |modal                   |\n",
+       "|LAI 300m    |v1      |NOBS               |modal                   |\n",
+       "|LAI 300m    |v1      |QFLAG              |modal                   |\n",
+       "|FAPAR 300m  |v1      |FAPAR              |mean                    |\n",
+       "|FAPAR 300m  |v1      |RMSE               |mean                    |\n",
+       "|FAPAR 300m  |v1      |LENGTH_AFTER       |modal                   |\n",
+       "|FAPAR 300m  |v1      |LENGTH_BEFORE      |modal                   |\n",
+       "|FAPAR 300m  |v1      |NOBS               |modal                   |\n",
+       "|FAPAR 300m  |v1      |QFLAG              |modal                   |\n",
+       "|FCOVER 300m |v1      |FCOVER             |mean                    |\n",
+       "|FCOVER 300m |v1      |RMSE               |mean                    |\n",
+       "|FCOVER 300m |v1      |LENGTH_AFTER       |modal                   |\n",
+       "|FCOVER 300m |v1      |LENGTH_BEFORE      |modal                   |\n",
+       "|FCOVER 300m |v1      |NOBS               |modal                   |\n",
+       "|FCOVER 300m |v1      |QFLAG              |modal                   |\n",
+       "|DMP 300m    |v1      |DMP                |mean                    |\n",
+       "|DMP 300m    |v1      |QFLAG              |modal                   |\n",
+       "|GDMP 300m   |v1      |GDMP               |mean                    |\n",
+       "|GDMP 300m   |v1      |QFLAG              |modal                   |"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "kable(cutoff_method_df[, c(1:3, 9)], caption = \"\")"
    ]
@@ -300,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -368,7 +466,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Step 5: Check the outcome and final remarks\n",
+    "# Step 6: Check the outcome and final remarks\n",
     "\n",
     "Here are a couple of plots in case the user wants to take a look at the resampled map."
    ]
@@ -408,6 +506,19 @@
    "cell_metadata_filter": "echo,tags,-all",
    "main_language": "R",
    "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "4.0.1"
   }
  },
  "nbformat": 4,

--- a/ResampleTool_R_notebook.ipynb
+++ b/ResampleTool_R_notebook.ipynb
@@ -47,24 +47,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Loading required package: sp\n",
-      "\n",
-      "Loading required package: knitr\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "library(raster)\n",
     "if(require(knitr) == FALSE){install.packages(\"knitr\", repos = \"https://cloud.r-project.org\"); library(knitr)} else {library(knitr)}\n",
@@ -108,19 +97,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "lines_to_next_cell": 0
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1] \"The image is not the full product; therefore, extent needs to be checked\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if(extent(r)[1] < -180 & extent(r)[2] > 179.997 &\n",
     "   extent(r)[3] < -59.99554 & extent(r)[4] > 80){  # checking for full product (image)\n",
@@ -175,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -194,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "echo": true,
     "lines_to_next_cell": 2
@@ -240,52 +221,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\n",
-       "\n",
-       "Table: \n",
-       "\n",
-       "|Product     |Version |Data.layer.in.file | Bytes.per.Cell| Valid.DN.min| Valid.DN.max| Valid.physical.min| Valid.physical.max|\n",
-       "|:-----------|:-------|:------------------|--------------:|------------:|------------:|------------------:|------------------:|\n",
-       "|NDVI 300m   |v1      |NDVI               |              1|            0|          250|              -0.08|               0.92|\n",
-       "|NDVI 300m   |v1      |NDVI_unc           |              2|            0|         1000|               0.00|               1.00|\n",
-       "|LAI 300m    |v1      |LAI                |              1|            0|          210|               0.00|               7.00|\n",
-       "|LAI 300m    |v1      |RMSE               |              1|            0|          210|               0.00|               7.00|\n",
-       "|LAI 300m    |v1      |LENGTH_AFTER       |              1|            0|           60|               0.00|              60.00|\n",
-       "|LAI 300m    |v1      |LENGTH_BEFORE      |              1|           15|          210|              15.00|             210.00|\n",
-       "|LAI 300m    |v1      |NOBS               |              1|            0|           40|               0.00|              40.00|\n",
-       "|LAI 300m    |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
-       "|FAPAR 300m  |v1      |FAPAR              |              1|            0|          235|               0.00|               0.94|\n",
-       "|FAPAR 300m  |v1      |RMSE               |              1|            0|          235|               0.00|               0.94|\n",
-       "|FAPAR 300m  |v1      |LENGTH_AFTER       |              1|            0|           60|               0.00|              60.00|\n",
-       "|FAPAR 300m  |v1      |LENGTH_BEFORE      |              1|           15|          210|              15.00|             210.00|\n",
-       "|FAPAR 300m  |v1      |NOBS               |              1|            0|           40|               0.00|              40.00|\n",
-       "|FAPAR 300m  |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
-       "|FCOVER 300m |v1      |FCOVER             |              1|            0|          250|               0.00|               1.00|\n",
-       "|FCOVER 300m |v1      |RMSE               |              1|            0|          250|               0.00|               1.00|\n",
-       "|FCOVER 300m |v1      |LENGTH_AFTER       |              1|            0|           60|               0.00|              60.00|\n",
-       "|FCOVER 300m |v1      |LENGTH_BEFORE      |              1|           15|          210|              15.00|             210.00|\n",
-       "|FCOVER 300m |v1      |NOBS               |              1|            0|           40|               0.00|              40.00|\n",
-       "|FCOVER 300m |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
-       "|DMP 300m    |v1      |DMP                |              2|            0|        32767|               0.00|             327.67|\n",
-       "|DMP 300m    |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|\n",
-       "|GDMP 300m   |v1      |GDMP               |              2|            0|        32767|               0.00|             655.34|\n",
-       "|GDMP 300m   |v1      |QFLAG              |              1|            0|          255|               0.00|             255.00|"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cutoff_method_df <- read.csv(paste0(getwd(), \"/Table_cutoff_and_resampleMethod.csv\"),\n",
     "                             stringsAsFactors = FALSE,\n",
@@ -302,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -337,52 +279,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove_input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\n",
-       "\n",
-       "Table: \n",
-       "\n",
-       "|Product     |Version |Data.layer.in.file |Resample.method         |\n",
-       "|:-----------|:-------|:------------------|:-----------------------|\n",
-       "|NDVI 300m   |v1      |NDVI               |mean                    |\n",
-       "|NDVI 300m   |v1      |NDVI_unc           |uncertainty_propagation |\n",
-       "|LAI 300m    |v1      |LAI                |mean                    |\n",
-       "|LAI 300m    |v1      |RMSE               |mean                    |\n",
-       "|LAI 300m    |v1      |LENGTH_AFTER       |modal                   |\n",
-       "|LAI 300m    |v1      |LENGTH_BEFORE      |modal                   |\n",
-       "|LAI 300m    |v1      |NOBS               |modal                   |\n",
-       "|LAI 300m    |v1      |QFLAG              |modal                   |\n",
-       "|FAPAR 300m  |v1      |FAPAR              |mean                    |\n",
-       "|FAPAR 300m  |v1      |RMSE               |mean                    |\n",
-       "|FAPAR 300m  |v1      |LENGTH_AFTER       |modal                   |\n",
-       "|FAPAR 300m  |v1      |LENGTH_BEFORE      |modal                   |\n",
-       "|FAPAR 300m  |v1      |NOBS               |modal                   |\n",
-       "|FAPAR 300m  |v1      |QFLAG              |modal                   |\n",
-       "|FCOVER 300m |v1      |FCOVER             |mean                    |\n",
-       "|FCOVER 300m |v1      |RMSE               |mean                    |\n",
-       "|FCOVER 300m |v1      |LENGTH_AFTER       |modal                   |\n",
-       "|FCOVER 300m |v1      |LENGTH_BEFORE      |modal                   |\n",
-       "|FCOVER 300m |v1      |NOBS               |modal                   |\n",
-       "|FCOVER 300m |v1      |QFLAG              |modal                   |\n",
-       "|DMP 300m    |v1      |DMP                |mean                    |\n",
-       "|DMP 300m    |v1      |QFLAG              |modal                   |\n",
-       "|GDMP 300m   |v1      |GDMP               |mean                    |\n",
-       "|GDMP 300m   |v1      |QFLAG              |modal                   |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "kable(cutoff_method_df[, c(1:3, 9)], caption = \"\")"
    ]
@@ -398,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "lines_to_next_cell": 0
    },
@@ -489,6 +392,31 @@
    "outputs": [],
    "source": [
     "plot(r300m_resampled1km_Aggr, main = 'Resampled map to 1km')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Step 7: Write the outcome to the disk\n",
+    "If needed the resampled data can be written on the disk with the geographic extent defined in a separated .tfw file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "writeRaster(r,'test.tif',options=c('TFW=YES'))"
    ]
   },
   {


### PR DESCRIPTION
If the mask is built over the entire dataset the system is eager of memory and can create problems to users.
Delaying masking after the coordinate slice decrease the memory usage as create the mask only over the AOI. 